### PR TITLE
Require >=PHP-7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
+        "php": ">=7.0",
         "aura/di": "~3.0",
         "aura/cli": "~2.0"
     },


### PR DESCRIPTION
I'm pretty sure the syntax like [this](https://github.com/cadrephp/Cadre.CliAdr/blob/0.x/src/Adr.php#L28) (sorry can't think of the proper term) wont work pre php7